### PR TITLE
Insert small image to QR Code

### DIFF
--- a/flask_qrcode/__init__.py
+++ b/flask_qrcode/__init__.py
@@ -1,46 +1,51 @@
 # coding=utf-8
+import os
 import base64
 from io import BytesIO
+try:
+    from urllib import urlopen  # py2
+except:
+    from urllib.request import urlopen  # py3
 
+from PIL import Image
 import qrcode as qrc
 from flask import Blueprint
 
-correction_levels = {
-    'L': qrc.constants.ERROR_CORRECT_L,
-    'M': qrc.constants.ERROR_CORRECT_M,
-    'Q': qrc.constants.ERROR_CORRECT_Q,
-    'H': qrc.constants.ERROR_CORRECT_H
-}
-
-
-def qrcode(data, version=None, error_correction='L', box_size=10, border=0, fit=True):
-    """ makes qr image using qrcode as qrc See documentation for qrcode package for info"""
-    qr = qrc.QRCode(
-        version=version,
-        error_correction=correction_levels[error_correction],
-        box_size=box_size,
-        border=border
-    )
-    qr.add_data(data)
-    qr.make(fit=fit)
-
-    # creates qrcode base64
-    out = BytesIO()
-    qr_img = qr.make_image()
-    qr_img.save(out, 'PNG')
-
-    return u"data:image/png;base64," + base64.b64encode(out.getvalue()).decode('ascii')
-
 
 class QRcode(object):
-    def __init__(self, app=None, **kwargs):
+    """Generate QR Code image"""
+    color = ['red', 'maroon', 'olive', 'yellow', 'lime', 'green',
+             'aqua', 'teal', 'blue', 'navy', 'fuchsia', 'purple',
+             'white', 'silver', 'gray', 'black']
+
+    correction_levels = {
+        'L': qrc.constants.ERROR_CORRECT_L,
+        'M': qrc.constants.ERROR_CORRECT_M,
+        'Q': qrc.constants.ERROR_CORRECT_Q,
+        'H': qrc.constants.ERROR_CORRECT_H
+    }
+
+    def __init__(self, app=None, config_jinja=True, **kwargs):
+        self.app = app
+        self._config_jinja = config_jinja
+
         if app:
             self.init_app(app)
 
+    def __call__(self, *args, **kwargs):
+        return self.qrcode(*args, **kwargs)
+
     def init_app(self, app):
+        self.app = app
         self.register_blueprint(app)
-        app.add_template_filter(qrcode)
-        app.add_template_global(qrcode)
+
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        app.extensions['qrcode'] = self
+
+        if self._config_jinja:
+            app.add_template_filter(self.qrcode, 'qrcode')
+            app.add_template_global(self.qrcode, 'qrcode')
 
     def register_blueprint(self, app):
         module = Blueprint('qrcode',
@@ -48,3 +53,76 @@ class QRcode(object):
                            template_folder='templates')
         app.register_blueprint(module)
         return module
+
+    def qrcode(self, data, mode="base64", version=None, error_correction="L", box_size=10,
+               border=0, fit=True, fill_color="black", back_color="white", **kwargs):
+        """
+        Makes qr image using qrcode as qrc. See documentation
+        for qrcode package for info.
+
+        :param data: String data.
+        :param mode: Output mode, [base64|raw].
+        :param version: The size of the QR Code (1-40).
+        :param error_correction: The error correction used for the QR Code.
+        :param box_size: How many pixels each "box" of the QR code.
+        :param border: The number of box for border.
+        :param fit: If `True`, find the best fit for the data.
+        :param fill_color: Frontend color.
+        :param back_color: Background color.
+
+        :param icon_img: Small icon image name or url.
+        :param factor: Resize for icon image (default: 4, one-fourth of QRCode)
+        :param icon_box: Icon image position [left, top] (default: image center)
+        """
+        qr = qrc.QRCode(
+            version=version,
+            error_correction=self.correction_levels[error_correction],
+            box_size=box_size,
+            border=border
+        )
+        qr.add_data(data)
+        qr.make(fit=fit)
+
+        fcolor = fill_color if fill_color.lower() in self.color or \
+            fill_color.startswith('#') else "#"+fill_color
+        bcolor = back_color if back_color.lower() in self.color or \
+            back_color.startswith('#') else "#"+back_color
+
+        # creates qrcode base64
+        out = BytesIO()
+        qr_img = qr.make_image(back_color=fcolor, fill_color=bcolor)
+        qr_img = qr_img.convert("RGBA")
+        qr_img = self._insert_img(qr_img, **kwargs)
+        qr_img.save(out, 'PNG')
+        out.seek(0)
+
+        if mode == 'base64':
+            return u"data:image/png;base64," + base64.b64encode(out.getvalue()).decode('ascii')
+        elif mode == 'raw':
+            return out
+
+    def _insert_img(self, qr_img, icon_img=None, factor=4, icon_box=None):
+        """Insert small icon to QR Code image"""
+        img_w, img_h = qr_img.size
+        size_w = int(img_w) / int(factor)
+        size_h = int(img_h) / int(factor)
+
+        try:
+            icon_fp = os.path.join(self.app.static_folder, icon_img)
+            if icon_img.split('://')[0] in ['http', 'https', 'ftp']:
+                icon_fp = BytesIO(urlopen(icon_img).read())
+            icon = Image.open(icon_fp)
+        except:
+            return qr_img
+
+        icon_w, icon_h = icon.size
+        icon_w = size_w if icon_w > size_w else icon_w
+        icon_h = size_h if icon_h > size_h else icon_h
+        icon = icon.resize((int(icon_w), int(icon_h)), Image.ANTIALIAS)
+        icon = icon.convert('RGBA')
+
+        left = int((img_w - icon_w) / 2)
+        top = int((img_h - icon_h) / 2)
+        icon_box = (int(icon_box[0]), int(icon_box[1])) if icon_box else (left, top)
+        qr_img.paste(im=icon, box=icon_box, mask=icon)
+        return qr_img

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==0.10.1
 qrcode==5.0.1
 Pillow==2.5.1
+pytest==3.0.4

--- a/sample_application/sample_application.py
+++ b/sample_application/sample_application.py
@@ -1,15 +1,26 @@
 # coding=utf-8
-from flask import Flask, render_template
+from flask import Flask, render_template, request, send_file
 
-from flask.ext.qrcode import QRcode
+from flask_qrcode import QRcode
+
 
 app = Flask(__name__)
-QRcode(app)
+qrcode = QRcode(app)
 
 
 @app.route('/')
 def index():
     return render_template('sample_application.html')
+
+
+@app.route('/qrcode', methods=['GET'])
+def get_qrcode():
+    # please get /qrcode?data=<qrcode_data>
+    data = request.args.get('data', '')
+    return send_file(
+        qrcode(data, mode='raw'),
+        mimetype='image/png'
+    )
 
 
 if __name__ == '__main__':

--- a/sample_application/templates/sample_application.html
+++ b/sample_application/templates/sample_application.html
@@ -28,5 +28,17 @@
 
         <h2>&lt;img src="&#123;&#123; qrcode("FATALITY", box_size=12, border=5) &#125;&#125;"&gt;</h2>
             <img src="{{ qrcode("FATALITY", box_size=12, border=5) }}">
+
+        <h1>A color QR example:</h1>
+
+        <h2>&lt;img src="&#123;&#123; qrcode("You can see green front color and #CCC back color.", error_correction='H', back_color='ccc', fill_color='green') &#125;&#125;"&gt;</h2>
+            <img src="{{ qrcode("You can see green front color and #CCC back color.", error_correction='H', back_color='ccc', fill_color='green') }}">
+        <br>
+
+        <h1>A icon image QR example:</h1>
+
+        <h2>&lt;img src="&#123;&#123; qrcode("You can see a icon in QR code.", error_correction='H', icon_img='https://avatars2.githubusercontent.com/u/5016303') &#125;&#125;"&gt;</h2>
+            <img src="{{ qrcode("You can see a icon in QR code.", error_correction='H', icon_img='https://avatars2.githubusercontent.com/u/5016303') }}">
+        <br>
     </body>
 </html>


### PR DESCRIPTION
I think, it's very useful. It have following new features:
- insert small icon to QR Code by `icon_img` (support `http`, `https`, `ftp` protocol)
- resize and position for small icon by `factor` and `box`
- set front and background color with QR Code by `fill_color` and `back_color`
- python 2 & python 3

For example:

```
<img src="{{ qrcode(request.url, fill_color="#aaa", back_color="white") }}">
<img src="{{ qrcode(url_for('.post', id=post.id, _external=True), border=1, factor=5, icon_img="https://example.org/fedora.png", box=(50, 100)) }}">
```

The `icon_img` will be find image in `static` directory. The `factory` will adjust the image size to one-fifth of QRCode. The `box` will be set `left: 50px` and `top: 100px` for small icon.

Please visit [blog](https://repo.fdzh.org/blog) to check QR Code image. @marcoagner

![](https://repo.fdzh.org/blog/api/v1.0/qrcode?url=https://www.google.com&version=10&correct=H&box_size=4&border=2&bcolor=ccc&fcolor=blue&icon=https://avatars0.githubusercontent.com/u/8544397&box=30,65)
`https://repo.fdzh.org/blog/api/v1.0/qrcode?url=https://www.google.com&version=10&correct=H&box_size=4&border=2&bcolor=ccc&fcolor=blue&icon=https://avatars0.githubusercontent.com/u/8544397&box=30,65`
