### PR TITLE
bumping version for docs and restricting jinja version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,9 @@ copyright = "2014-2018, Marco Agner"
 author = "Marco Agner"
 
 # The short X.Y version
-version = "3.0.0"
+version = "3.1.0"
 # The full version, including alpha/beta/rc tags
-release = "v3.0.0"
+release = "v3.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@
 pytest==3.4.1
 sphinx==1.7.1
 Flask-Sphinx-Themes==1.0.2
+jinja2<3.1.0


### PR DESCRIPTION
Raising the version of the image and updating the environment for development, because of the https://github.com/readthedocs/readthedocs.org/issues/9037 issue