### PR TITLE
updated to newer pillow and qr code version

### DIFF
--- a/flask_qrcode/__init__.py
+++ b/flask_qrcode/__init__.py
@@ -203,7 +203,7 @@ class QRcode(object):
         icon_w, icon_h = icon.size
         icon_w = size_w if icon_w > size_w else icon_w
         icon_h = size_h if icon_h > size_h else icon_h
-        icon = icon.resize((int(icon_w), int(icon_h)), Image.ANTIALIAS)
+        icon = icon.resize((int(icon_w), int(icon_h)), Image.Resampling.LANCZOS)
         icon = icon.convert("RGBA")
 
         left = int((img_w - icon_w) / 2)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 Flask>=0.12.3
 qrcode>=6.1,<7.4
-pillow>=9.0.0
+pillow>=9.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 Flask>=0.12.3
-qrcode==6.1
-Pillow>=5.0.0
+qrcode>=6.1,<7.4
+pillow>=9.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-pytest==3.4.1
-sphinx==1.7.1
+pytest==6.2.5
+Sphinx==1.7.1
 Flask-Sphinx-Themes==1.0.2
-jinja2<3.1.0
+Jinja2<3.1.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class PyTest(TestCommand):
 
 setup(
     name="Flask-QRcode",
-    version="3.1.0",
+    version="3.2.0",
     license="GPLv3",
     description="A concise Flask extension to render QR codes on Jinja2 "
     "templates using python-qrcode",
@@ -71,6 +71,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tests/server.py
+++ b/tests/server.py
@@ -30,6 +30,5 @@ class TestServer(socketserver.TCPServer):
 def start_test_server(port=5000):
     handler = http.server.SimpleHTTPRequestHandler
     httpd = TestServer(("", port), handler)
-    httpd_thread = threading.Thread(target=httpd.serve_forever)
-    httpd_thread.setDaemon(True)
+    httpd_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     httpd_thread.start()


### PR DESCRIPTION
Fixes #40 
I needed to update pytest to make it run on newer dependencies and locally I tested that the tests pass with the qrcode library up to 7.3.
See https://github.com/python-pillow/Pillow/compare/8.4.0...9.1.0#diff-5825171055ba5907fd9759b4a5fd5c7fbd369e19df27d7bcf312398f993432e4R849 that's why I allow 9.1 in the newer library.